### PR TITLE
adjust Fig 7 to encompass 1 intead of 2 columns to shorten the paper

### DIFF
--- a/papers/serge_rey/serge_rey.rst
+++ b/papers/serge_rey/serge_rey.rst
@@ -652,8 +652,6 @@ Sequence Analysis to Neighborhood Change
 
 
 .. figure:: hamming_and_weighted.png
-   :align: center
-   :figclass: w
 
    Neighborhoods with similar spatial-social histories since 1980 :label:`f:trajclust`
 


### PR DESCRIPTION
### Fig 7 is originally set to encompass 2 columns:
![image](https://user-images.githubusercontent.com/7359284/42399088-522ef822-8121-11e8-9de9-54226199587e.png)

### We could adjust it to encompass only 1 column make the paper have a shorter length:

![image](https://user-images.githubusercontent.com/7359284/42399151-91611aac-8121-11e8-97e3-b3f4a33cb292.png)


